### PR TITLE
anrcore: fix missing calls to CALLGRIND_TOGGLE_COLLECT

### DIFF
--- a/src/anrcore.c
+++ b/src/anrcore.c
@@ -1578,6 +1578,7 @@ valgrind_make_internals_defined(malloc_state_t * self)
     if (RARELY(self->def_count != 0)) {
         self->def_count++;
         UNLOCK(&self->heap_lock);
+        CALLGRIND_TOGGLE_COLLECT;
         return;
     }
     self->def_count++;
@@ -1622,6 +1623,7 @@ valgrind_make_internals_noaccess(malloc_state_t *self)
 
     if (RARELY (self->def_count != 0)) {
         UNLOCK(&self->heap_lock);
+        CALLGRIND_TOGGLE_COLLECT;
         return;
     }
 


### PR DESCRIPTION
Several early return paths missed calling CALLGRIND_TOGGLE_COLLECT.
This causes callgrind to get out of sync and to report anrmalloc as
consuming most of the run time.

Signed-off-by: Steven Walter swalter@lexmark.com
